### PR TITLE
Address and port check before selectIPAddressAndPort 

### DIFF
--- a/www/js/DestinationManager.js
+++ b/www/js/DestinationManager.js
@@ -169,9 +169,11 @@ function DestinationManager() {
 	
 	this.selectIPAddressAndPort = function(address, port) {
         console.log("selecting ip and port");
-		this.ipaddress = address;
-		this.port = port;
-		PhoneGap.exec("OSCManager.setIPAddressAndPort", this.ipaddress, this.port);
+        if(this.ipaddress != address || this.port != port){
+            this.ipaddress = address;
+            this.port = port;
+            PhoneGap.exec("OSCManager.setIPAddressAndPort", this.ipaddress, this.port);
+        }
 	}
 	
 	this.promptForIP = function() { // TODO: NO ABSOLUTE PIXEL VALUES. SHEESH.


### PR DESCRIPTION
I had a big performance problem every time i send an interface over OSC to my iPad, and also told it my IP address, the interface became more and more unresponsive and i had to restart Control. I found the problem, and it was that the PhoneGap command selectIPAddressAndPort is making trouble, but since i send the same ip and port every time, there was no reason for it to be called. 
